### PR TITLE
Update fix_esri_polygon for fixed gdal

### DIFF
--- a/download_ta_bdys.py
+++ b/download_ta_bdys.py
@@ -73,6 +73,9 @@ def ring_is_clockwise(ring):
 
 # this is required because of a bug in OGR http://trac.osgeo.org/gdal/ticket/5538
 def fix_esri_polyon(geom):
+    if geom.GetGeometryType() == ogr.wkbMultiPolygon:
+        return geom
+
     polygons = []
     count = geom.GetGeometryCount()
     if count > 0:


### PR DESCRIPTION
https://trac.osgeo.org/gdal/ticket/5538 has now been fixed, but `fix_esri_polygon()` throws an error with newer GDAL releases, because it assumes the passed geometry is a Polygon, not a MultiPolygon.
